### PR TITLE
upgrading dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "meta-router",
+    "version": "1.0.7",
     "description": "Declarative URL router for Express that provides support for associating metadata with a route.",
     "main": "lib/index.js",
     "scripts": {
@@ -24,8 +25,8 @@
     "homepage": "https://github.com/patrick-steele-idem/meta-router",
     "dependencies": {
         "jsonminify": "^0.2.3",
-        "path-to-regexp": "^0.2.3",
-        "raptor-async": "^0.2.8-beta",
+        "path-to-regexp": "^1.0.1",
+        "raptor-async": "^1.0.1",
         "resolve-from": "^1.0.0",
         "shortstop": "^1.0.1",
         "shortstop-handlers": "^1.0.0"
@@ -36,6 +37,5 @@
         "jshint": "^2.5.2",
         "mocha": "^1.21.3",
         "request": "^2.39.0"
-    },
-    "version": "1.0.6"
+    }
 }


### PR DESCRIPTION
Hi @patrick-steele-idem, removing -beta dependency from raptor-async + upgrading to path-to-regexp@^1
