### PR TITLE
fix: import route json file for better file watching with macro

### DIFF
--- a/test/fixtures/macro/extended/output.js
+++ b/test/fixtures/macro/extended/output.js
@@ -9,3 +9,5 @@ module.exports = [{
   "path": "GET /bar",
   "handler": require("./../../user.js").bar
 }];
+
+require("../../routes.json");

--- a/test/fixtures/macro/shorthand/output.js
+++ b/test/fixtures/macro/shorthand/output.js
@@ -9,3 +9,5 @@ module.exports = [{
   "path": "GET /bar",
   "handler": require("./../../user-with-meta.js").bar
 }];
+
+require("../../routes-shorthand.json");


### PR DESCRIPTION
Currently when using the macro with a tool like webpack/rollup or anything that relies on the module graph for file watching, when the routes config file changes the build will not update.

This PR adds a require to the routes.json file at the end the file via the macro to ensure that it is part of the module graph.